### PR TITLE
chore: remove reviewers from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - tkrs
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - tkrs


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/